### PR TITLE
Add support for logsets (aggregated logs from multiple hosts)

### DIFF
--- a/logentries/attributes/default.rb
+++ b/logentries/attributes/default.rb
@@ -1,4 +1,5 @@
-default[:logentries][:logs][:syslog] = { "filename" => '/var/log/syslog', 'name' => 'syslog', 'type' => 'syslog' }
 default[:logentries][:logs][:chefclient] = { "filename" => '/var/log/chef/client.log', 'name' => 'chef-client.log', 'type' => 'syslog' }
 default[:logentries][:logs][:cloudinit] = { "filename" => '/var/log/cloud-init.log', 'name' => 'cloud-init.log', 'type' => 'syslog' }
 default[:logentries][:logs][:kern] = { "filename" => '/var/log/kern.log', 'name' => 'kern.log', 'type' => 'syslog' }
+
+default[:logentries][:logsets][:syslog] = { "filename" => '/var/log/syslog', 'name' => 'syslog', 'type' => 'syslog' }

--- a/logentries/attributes/default.rb
+++ b/logentries/attributes/default.rb
@@ -1,5 +1,5 @@
-default[:logentries][:logs][:chefclient] = { "filename" => '/var/log/chef/client.log', 'name' => 'chef-client.log', 'type' => 'syslog' }
-default[:logentries][:logs][:cloudinit] = { "filename" => '/var/log/cloud-init.log', 'name' => 'cloud-init.log', 'type' => 'syslog' }
-default[:logentries][:logs][:kern] = { "filename" => '/var/log/kern.log', 'name' => 'kern.log', 'type' => 'syslog' }
+default[:logentries][:logs][:chefclient] = { "filename" => '/var/log/chef/client.log', 'name' => 'chef-client.log' }
+default[:logentries][:logs][:cloudinit] = { "filename" => '/var/log/cloud-init.log', 'name' => 'cloud-init.log' }
+default[:logentries][:logs][:kern] = { "filename" => '/var/log/kern.log', 'name' => 'kern.log' }
 
-default[:logentries][:logsets][:syslog] = { "filename" => '/var/log/syslog', 'name' => 'syslog', 'type' => 'syslog' }
+default[:logentries][:logsets][:syslog] = { "filename" => '/var/log/syslog', 'name' => 'syslog' }

--- a/logentries/libraries/logentries.rb
+++ b/logentries/libraries/logentries.rb
@@ -10,7 +10,7 @@ class Logentries < Chef::Recipe
   # - checks if we are already following this log
   def follow(log)
     Chef::Log.info "follow log #{log[:filename]}"
-    execute "le follow '#{log[:filename]}' --name=#{log[:name]} --type=#{log[:type]}" do
+    execute "le follow '#{log[:filename]}' --name=#{log[:name]}" do
       not_if "le followed #{log[:filename]}"
     end
   end

--- a/logentries/libraries/logentries.rb
+++ b/logentries/libraries/logentries.rb
@@ -1,14 +1,13 @@
 class Logentries < Chef::Recipe
   # Register the host with the given hostname via userkey with logentries
   def register(userkey, hostname)
-    execute "le register --user-key #{userkey}  --name='#{hostname}'" do
-      not_if "test -e /etc/le/config"
+    execute "le register --user-key #{userkey} --name='#{hostname}'" do
+      not_if "cat /etc/le/config | grep agent-key"
     end
   end
-  
-  
+
   # Follows the given log, given by filename, name and type
-  # - checks if we already following this log
+  # - checks if we are already following this log
   def follow(log)
     Chef::Log.info "follow log #{log[:filename]}"
     execute "le follow '#{log[:filename]}' --name=#{log[:name]} --type=#{log[:type]}" do

--- a/logentries/metadata.rb
+++ b/logentries/metadata.rb
@@ -1,6 +1,7 @@
+name "logentries"
 maintainer "Tobias Wilken"
 maintainer_email "tw@cloudcontrol.de"
 license "Apache 2.0"
 description "Installs and configures Logentries"
-version "0.2.1"
+version "0.2.2"
 depends "apt"

--- a/logentries/templates/default/config.erb
+++ b/logentries/templates/default/config.erb
@@ -1,0 +1,17 @@
+[Main]
+hostname = <%= node[:hostname] %>
+metrics-cpu = system
+metrics-vcpu = core
+metrics-mem = system
+metrics-swap = system
+metrics-net = sum select
+metrics-disk = sum
+metrics-space = /
+metrics-interval = 5s
+
+<% node[:logentries][:logsets].each do |key, log| %>
+
+[<%= log[:name] || key %>]
+path = <%= log[:filename] %>
+destination = <%= node[:hostname].split('-')[0] %>/<%= log[:name] || key %>
+<% end %>


### PR DESCRIPTION
- default[:logentries][:logs] are followed per host
- default[:logentries][:logsets] are aggregated in a logset
  named after the first part of the hostname. E.g. for
  lxc-dev-muycqh the logset would be called lxc
